### PR TITLE
Fix Tomorrow Night Eighties theme name

### DIFF
--- a/tomorrow-night-eighties.yaml
+++ b/tomorrow-night-eighties.yaml
@@ -1,4 +1,4 @@
-scheme: "Tomorrow Night"
+scheme: "Tomorrow Night Eighties"
 author: "Chris Kempson (http://chriskempson.com)"
 base00: "2d2d2d"
 base01: "393939"


### PR DESCRIPTION
I believe the name is a mistake. Furthermore, having two themes with the same names prevents any tools to browse themes that refers to them by name to work efficiently.